### PR TITLE
Résoudre Hx = b avec des rotations de Givens puis un "backsolve"

### DIFF
--- a/exercice.jl
+++ b/exercice.jl
@@ -4,11 +4,17 @@ using LinearAlgebra
 #    du système triangulaire supérieur Rx = b.
 #    Votre fonction ne doit modifier ni R ni b.
 function backsolve(R::UpperTriangular, b)
-  x = similar(b)
-  ### votre code ici ; ne rien modifier d'autre
-  # ...
-  ###
-  return x
+    x = copy(b)
+
+    # m == n
+    m,n = size(R)
+    for j = n:-1:1
+        x[j] /= R[j,j]
+        for i = j-1:-1:1
+            x[i] -= (R[i,j] * x[j])
+         end
+    end    
+    return x
 end
 
 # 2. Modifiez la fonction suivante pour qu'elle renvoie la solution x
@@ -19,15 +25,25 @@ end
 #    fonction ne doit pas les renvoyer.
 #    Seul le cas réel sera testé ; pas le cas complexe.
 function hessenberg_solve(H::UpperHessenberg, b)
-  ### votre code ici ; ne rien modifier d'autre
-  # ...
-  # x = ...
-  ###
-  return x
+    x = similar(b)
+    m,n = size(H)
+    for i = 1:n-1
+        ρ = H[i,i]^2 + H[i+1,i]^2
+        c = H[i,i] / ρ
+        s = H[i+1,i] / ρ
+       
+        givens_rotation_mat = [c s; -s c]
+        H[i:i+1,i:end] .= givens_rotation_mat * H[i:i+1,i:end]
+        b[i:i+1] .= givens_rotation_mat * b[i:i+1]
+    end
+
+    R = UpperTriangular(H)
+    return backsolve(R,b)
 end
 
 # vérification
 using Test
+
 for n ∈ (10, 20, 30)
   A = rand(n, n)
   b = rand(n)
@@ -38,3 +54,4 @@ for n ∈ (10, 20, 30)
   x = hessenberg_solve(copy(H), copy(b))
   @test norm(H * x - b) ≤ sqrt(eps()) * norm(b)
 end
+


### PR DESCRIPTION
1. Pour chaque élement sous la diagonale, on applique une rotation de Givens sur la ligne de cet élement et la ligne immédiatement au-dessus. On se retrouve avec une matrice triangulaire supérieure R. On applique également la rotation sur le vecteur b.

2. Pour résoudre le système Rx = b, on procède ainsi :
On initialise le vecteur x avec le contenu de b. À chaque fois que l'on calcule la valeur d'une variable x[j], on fait passer cette valeur à la droite de l'équation, en faisant $x = x - R_{j,j}x_j$. À chaque fois que l'on fait passer cette valeur à droite de l'équation, on peut retrouver la prochaine variable x[j] étant donné que R est triangulaire supérieure.