### PR TITLE
TP-2 résolution de Hessenberg

### DIFF
--- a/exercice.jl
+++ b/exercice.jl
@@ -4,10 +4,17 @@ using LinearAlgebra
 #    du système triangulaire supérieur Rx = b.
 #    Votre fonction ne doit modifier ni R ni b.
 function backsolve(R::UpperTriangular, b)
-  x = similar(b)
   ### votre code ici ; ne rien modifier d'autre
-  # ...
-  ###
+  # Pour faire du code efficace on fait une copie de b dans x
+  n = length(b)
+  x = copy(b)
+  for i in n:-1:1
+      @assert R[i, i] != 0
+      for j=i+1:n
+        x[i] -= R[i, j] * x[j]
+      end
+      x[i] /= R[i, i]
+  end
   return x
 end
 
@@ -20,9 +27,32 @@ end
 #    Seul le cas réel sera testé ; pas le cas complexe.
 function hessenberg_solve(H::UpperHessenberg, b)
   ### votre code ici ; ne rien modifier d'autre
-  # ...
-  # x = ...
-  ###
+  n = size(H, 1)
+  for i in 1:n-1
+      a = H[i, i]
+      b_val = H[i+1, i]
+      r = sqrt(a^2 + b_val^2)
+      # Definir les coefficients de la rotation de Givens
+      c = a / r
+      s = b_val / r
+
+      # Appliquer les rotations de Givens à H
+      for j in i:n
+          t1 = H[i, j]
+          t2 = H[i+1, j]
+          H[i, j] = c * t1 + s * t2
+          H[i+1, j] = -s * t1 + c * t2
+      end
+
+      # Appliquer les rotations de Givens à b aussi
+      t1 = b[i]
+      t2 = b[i+1]
+      b[i] = c * t1 + s * t2
+      b[i+1] = -s * t1 + c * t2
+  end
+
+  # Maintenant on peut résoudre le système triangulaire supérieur
+  x = backsolve(UpperTriangular(H), b)
   return x
 end
 


### PR DESCRIPTION
Ici on code la résolution du système linéaire de Hessenberg en le transformant grâce aux rotations de Givens à un système triangulaire supérieur.

Le test semble être pas bien posé car il peut y avoir des échecs pour résoudre un problème triangulaire supérieur car la matrice A définie random et dont les coefficients sont entre 0 et 1 risque d'être non inversible ou avoir des valeurs propres de plus en plus petites et c'est ce qu'on voit si on augmente les dimensions and élastiques de 30, le test ne marche plus, pour y remédier (en discutant avec Alexis) on pourrait switcher la diagonale de A comme ceci:
$$A = I + rand(n,n)$$
Comme ça on est sûr que les valeurs propres du problème triangulaire supérieur se situent autour de 1 aulique de 0, ce qui permet plus de stabilité numérique.